### PR TITLE
pálya alapszín módosítás

### DIFF
--- a/src/GUI/view/panels/MapPanel.java
+++ b/src/GUI/view/panels/MapPanel.java
@@ -32,6 +32,14 @@ public class MapPanel extends JPanel implements View {
      */
     ArrayList<FieldView> neighbourFields;
 
+
+    /**
+     * @return Base color of the map
+     */
+    public static Color getFieldColor(){
+        return new Color(4, 73, 20);
+    }
+
     /**
      * Creates a map panel
      */

--- a/src/GUI/view/view/fieldView/FieldView.java
+++ b/src/GUI/view/view/fieldView/FieldView.java
@@ -1,6 +1,7 @@
 package GUI.view.view.fieldView;
 
 import GUI.view.frames.GameFrame;
+import GUI.view.panels.MapPanel;
 import GUI.view.view.View;
 import GUI.view.view.VirologistView;
 import GUI.view.view.equipmentView.EquipmentView;
@@ -56,7 +57,7 @@ public class FieldView extends JPanel implements View, MouseListener {
      * ctr
      */
     public FieldView(){
-        color = new Color(3, 18, 9);
+        color = MapPanel.getFieldColor();
         newImage = Toolkit.getDefaultToolkit().createImage("resources/field1.png");
         backGround = newImage.getScaledInstance(198,198,Image.SCALE_DEFAULT);
         this.setOpaque(false);

--- a/src/GUI/view/view/fieldView/LaboratoryView.java
+++ b/src/GUI/view/view/fieldView/LaboratoryView.java
@@ -1,5 +1,6 @@
 package GUI.view.view.fieldView;
 
+import GUI.view.panels.MapPanel;
 import GUI.view.view.VirologistView;
 import GUI.view.view.geneticCodeView.*;
 import main.com.teamalfa.blindvirologists.agents.genetic_code.*;
@@ -26,7 +27,7 @@ public class LaboratoryView extends FieldView{
      * ctr
      */
     public LaboratoryView(){
-        color = new Color(3, 18, 9);
+        color = MapPanel.getFieldColor();
         newImage = Toolkit.getDefaultToolkit().createImage("resources/lab.png");
         backGround = newImage.getScaledInstance(315,315,Image.SCALE_DEFAULT);
         this.text = "lab";

--- a/src/GUI/view/view/fieldView/SafeHouseView.java
+++ b/src/GUI/view/view/fieldView/SafeHouseView.java
@@ -1,5 +1,6 @@
 package GUI.view.view.fieldView;
 
+import GUI.view.panels.MapPanel;
 import GUI.view.view.VirologistView;
 import GUI.view.view.equipmentView.*;
 import main.com.teamalfa.blindvirologists.city.fields.SafeHouse;
@@ -31,7 +32,7 @@ public class SafeHouseView extends FieldView{
      * ctr
      */
     public SafeHouseView(){
-        color = new Color(3, 18, 9);
+        color = MapPanel.getFieldColor();
         newImage = Toolkit.getDefaultToolkit().createImage("resources/SafeHouse1.png");
         backGround = newImage.getScaledInstance(200,200,Image.SCALE_DEFAULT);
         this.text = "safe";

--- a/src/GUI/view/view/fieldView/StoreHouseView.java
+++ b/src/GUI/view/view/fieldView/StoreHouseView.java
@@ -1,5 +1,6 @@
 package GUI.view.view.fieldView;
 
+import GUI.view.panels.MapPanel;
 import GUI.view.view.ElementView;
 import GUI.view.view.VirologistView;
 import main.com.teamalfa.blindvirologists.city.fields.StoreHouse;
@@ -25,7 +26,7 @@ public class StoreHouseView extends FieldView {
      * ctr
      */
     public StoreHouseView(){
-        color = new Color(3, 18, 9);
+        color = MapPanel.getFieldColor();
         newImage = Toolkit.getDefaultToolkit().createImage("resources/StoreHouse1.png");
         backGround = newImage.getScaledInstance(200,200,Image.SCALE_DEFAULT);
         this.text = "store";


### PR DESCRIPTION
- A pálya alapszíne világosabb zöld lett, mivel alacsony képernyő fényerő mellett nem különböztethető meg a sötét háttérszinttől, ezzel akadájozva a használhatóságot.
- Új statikus függvény felvétele a MapPanel osztályba, amellyel lekérdezhető az aktuális pályaszín. (shotgun surgery elkerülése)